### PR TITLE
Linting rules

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,75 @@
+/**
+ * Project specific jshint linting options.
+ *
+ * Forked of Airbnb JSHint settings.
+ *
+ * @version 0.3.1
+ * @see     http://www.jshint.com/docs/
+ */
+{
+  /*
+   * ENVIRONMENTS
+   * =================
+   */
+
+  // Define globals exposed by modern browsers.
+  "browser": false,
+
+  // Define globals exposed by jQuery.
+  "jquery": false,
+
+  // Define globals exposed by Node.js.
+  "node": true,
+
+  /*
+   * ENFORCING OPTIONS
+   * =================
+   */
+
+  // Force all variable names to use either camelCase style or UPPER_CASE
+  // with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "true",
+
+  // Prohibit trailing whitespace.
+  "trailing": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  // do not complain for lack of 'use strict';
+  "globalstrict": false,
+  "strict": false,
+
+  // suppress object dot notation warnings, we know what we're doing
+  "sub": true,
+
+
+  /**
+   * PROJECT GLOBALS
+   * ================
+   *
+   */
+  "predef": [
+  ]
+}


### PR DESCRIPTION
Some sensible linting rules so files won't light up with auto-linting...

The main problem was single/double quotes, so i had to set the `quotmark` directive to `true` to support both...
