### PR TITLE
Pass object as second arg to conform

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,10 +220,10 @@ var validate = mschema.validate = function (_data, _schema, options, cb) {
                 _parse(value, property);
                 return;
               } else {
-                checkConstraint(propertyName, constraint, property[constraint], value, errors);
+                checkConstraint(propertyName, constraint, property[constraint], value, data, errors);
               }
             } else {
-              checkConstraint(propertyName, constraint, property[constraint], value, errors);
+              checkConstraint(propertyName, constraint, property[constraint], value, data, errors);
             }
           }
         }
@@ -308,7 +308,7 @@ var validate = mschema.validate = function (_data, _schema, options, cb) {
   return result;
 };
 
-var checkConstraint = mschema.checkConstraint = function (property, constraint, expected, value, errors) {
+var checkConstraint = mschema.checkConstraint = function (property, constraint, expected, value, data, errors) {
 
   switch (constraint) {
 
@@ -401,7 +401,7 @@ var checkConstraint = mschema.checkConstraint = function (property, constraint, 
           message: 'conform property must be function'
         });
       } else {
-        var _value = expected(value);
+        var _value = expected(value, data);
         if (_value !== true && _value !== false) {
           errors.push({
             property: property,

--- a/test/constraint-conform-test.js
+++ b/test/constraint-conform-test.js
@@ -49,6 +49,40 @@ test("mschema.validate - valid data - constrained properties - conform", functio
 
 });
 
+test("mschema.validate - peer dependent data - constrained properties - conform", function (t) {
+
+  var user = {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "password": {
+      "type": "string",
+      "required": true
+    },
+    "confirmPassword": {
+      "type": "string",
+      "required": true,
+      "conform": function (val, user) {
+        return val === user.password
+      }
+    }
+  };
+
+  var data = {
+    "name": "Marak",
+    "password": "alpaca-nutmeg",
+    "confirmPassword": "alpaca-nutmeg"
+  };
+
+  var result = mschema.validate(data, user);
+
+  t.equal(result.valid, true);
+  t.ok(result, "peer dependent data is valid");
+  t.end();
+
+});
+
 test("mschema.validate - invalid data - constrained properties - conform", function (t) {
 
   var user = {


### PR DESCRIPTION
Property validation can involve adjacent values:

```js
{
  minimum: {
    type: 'number',
    conform: (val, {maximum}) => val > 0 && val < maximum
  },
  maximum: {
    type: 'number',
    conform: (val, {minimum}) => val > minimum
  }
}
```

@Marak I have a work project where we're using a private fork of mschema, any interest in me opening a couple PRs like this with some of our changes?