### PR TITLE
Add integer type and tweak coercion

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ mschema.types = {
   "number": function (val) {
     return typeof val === "number";
   },
+  "integer": function (val) {
+    return typeof val === "number" && val % 1 === 0;
+  },
   "boolean": function (val) {
     return typeof val === "boolean";
   },
@@ -74,10 +77,16 @@ var validate = mschema.validate = function (_data, _schema, options, cb) {
         if (options.strict === false) {
           var _value;
           // determine if any incoming data might need to be changed from a string number into a Number type
-          if (typeof value === "string" && (property === "number" || property.type === "number")) {
-            _value = parseInt(data[propertyName], 10);
+          if (typeof value === "string" && property.type === "number") {
+            _value = +value;
             if (_value.toString() !== "NaN") {
-              // a non NaN number was parsed, assign it as validation value and to instance value
+              value = _value;
+              data[propertyName] = value;
+            }
+          }
+          if (typeof value === "string" && property.type === "integer") {
+            _value = parseInt(value, 10);
+            if (_value.toString() !== "NaN") {
               value = _value;
               data[propertyName] = value;
             }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ var validate = mschema.validate = function (_data, _schema, options, cb) {
 
   function _parse (data, schema) {
 
+    var types = Object.keys(mschema.types)
+
     // iterate through properties and compare values to types
     for (var propertyName in schema) {
 
@@ -60,7 +62,7 @@ var validate = mschema.validate = function (_data, _schema, options, cb) {
       function parseConstraint (property, value) {
 
         // auto-types on string values ( will turn "foo": "string" into { type: "string", required: false }), etc
-        if (typeof property === "string" && (property === 'string' || property === 'number' || property === 'object' || property === 'array' || property === 'boolean' || property === 'any')) {
+        if (typeof property === "string" && (types.indexOf(property) !== -1)) {
           property = {
             "type": property,
             "required": false
@@ -97,7 +99,7 @@ var validate = mschema.validate = function (_data, _schema, options, cb) {
             data[propertyName] = value;
           }
           // determine if any incoming data might need to be changed from an html checkbox into a boolean
-          if (typeof value === "string" && (property === "boolean" || property.type === "boolean")) {
+          if (typeof value === "string" && (property.type === "boolean")) {
             if (value === "on") {
               value = true;
             }

--- a/test/non-strict-type-conversion-test.js
+++ b/test/non-strict-type-conversion-test.js
@@ -18,9 +18,14 @@ test("mschema.validate - { strict: false } - numbers as strings", function (t) {
       "enum": ["high", "medium", "low"]
     },
     "warheads": {
-      "type": "number",
+      "type": "integer",
       "min": 1,
       "max": 8
+    },
+    "fuel": {
+      "type": "number",
+      "min": 0,
+      "max": 100
     },
     "active": "boolean",
     "armed": "boolean",
@@ -31,6 +36,7 @@ test("mschema.validate - { strict: false } - numbers as strings", function (t) {
     "name": "small missle",
     "power": "low",
     "warheads": "5",
+    "fuel": "33.3",
     "active": "on",
     "armed": "off",
     "exploding": undefined
@@ -42,6 +48,7 @@ test("mschema.validate - { strict: false } - numbers as strings", function (t) {
   t.equal(validate.instance.armed, false);
   t.equal(validate.instance.exploding, false);
   t.equal(validate.instance.warheads, 5);
+  t.equal(validate.instance.fuel, 33.3);
   t.end();
 
 });

--- a/test/types-as-strings-test.js
+++ b/test/types-as-strings-test.js
@@ -16,7 +16,8 @@ test("mschema.validate - valid data - constrained property - type - string", fun
     "age": "number",
     "address": "object",
     "isActive": "boolean",
-    "meta": "any"
+    "meta": "any",
+    "collections": "integer"
   };
 
   var data = {
@@ -28,7 +29,8 @@ test("mschema.validate - valid data - constrained property - type - string", fun
       "zipcode": "12345-01"
     },
     "isActive": true,
-    "meta": 42
+    "meta": 42,
+    "collections": 30
   };
 
   var result = mschema.validate(data, user);
@@ -44,14 +46,16 @@ test("validate invalid data based on simple schema with properties", function (t
      "name": "string",
      "age": "number",
      "address": "object",
-     "isActive": "boolean"
+     "isActive": "boolean",
+     "collections": "integer"
    };
 
   var data = {
     "name": 100,
     "age": "abc",
     "address": "not an object",
-    "isActive": "not a boolean"
+    "isActive": "not a boolean",
+    "collections": 3.04
   };
 
   var result = mschema.validate(data, user);
@@ -59,7 +63,7 @@ test("validate invalid data based on simple schema with properties", function (t
   t.type(result.errors, Array)
   t.type(result.errors, Object);
 
-  t.equal(result.errors.length, 4);
+  t.equal(result.errors.length, 5);
 
   t.equal(result.errors[0].property, 'name');
   t.equal(result.errors[0].constraint, 'type');
@@ -84,6 +88,12 @@ test("validate invalid data based on simple schema with properties", function (t
   t.equal(result.errors[3].value, 'not a boolean');
   t.equal(result.errors[3].expected, 'boolean');
   t.equal(result.errors[3].actual, 'string');
+
+  t.equal(result.errors[4].property, 'collections');
+  t.equal(result.errors[4].constraint, 'type');
+  t.equal(result.errors[4].value, 3.04);
+  t.equal(result.errors[4].expected, 'integer');
+  t.equal(result.errors[4].actual, 'number');
 
   t.ok(result, "data is invalid");
   t.end();


### PR DESCRIPTION
I had a need to differentiate between integers and floats, and all numbers being coerced with `parseInt` made it hard to use `{strict: false}` mode.

- New integer type
- integer coerced with `parseInt`
- number coerced with `+`
