### PR TITLE
Add array type/array object literal syntax

### DIFF
--- a/test/array-typed-as-schema-test.js
+++ b/test/array-typed-as-schema-test.js
@@ -39,48 +39,6 @@ test("mschema.validate - valid data - constraint - array of objects", function (
 
 });
 
-test("mschema.validate - valid data - constraint - array of objects", function (t) {
-
-  var blog = {
-    "name": "string",
-    "posts": [{
-        "title": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 15
-        },
-        "content": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 15
-        }
-    },{
-        "a": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 15
-        },
-        "b": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 15
-        }
-    }]
-  };
-
-  var data = {
-    "name": "My Blog",
-    "posts": [{ "title": "a post", "content": "some content"}]
-  };
-
-  var result = mschema.validate(data, blog);
-  t.equal(result.valid, false);
-  t.ok(result, "schema is invalid");
-  t.equal(result.errors[0].message, 'Typed arrays can only be of one type');
-  t.end();
-
-});
-
 test("mschema.validate - invalid data - constraint - array of objects", function (t) {
 
   var blog = {

--- a/test/array-typed-as-strings-test.js
+++ b/test/array-typed-as-strings-test.js
@@ -77,21 +77,20 @@ test("mschema.validate - undefined array data - array of - string", function (t)
 
 test("mschema.validate - multiple array types in one array - string", function (t) {
 
-  var blog = {
+  var point = {
     "name": "string",
-    "posts": ["string", "string"]
+    "coords": ["number", "number"]
   };
 
   var data = {
-    "name": "My Blog",
-    "posts": []
+    "name": "missle base",
+    "coords": [42.544, -118.534]
   };
 
-  var result = mschema.validate(data, blog);
+  var result = mschema.validate(data, point);
 
-  t.equal(result.valid, false);
-  t.equal(result.errors[0].message, 'Typed arrays can only be of one type');
-  t.ok(result, "schema is invalid");
+  t.equal(result.valid, true);
+  t.ok(result, "data is valid");
   t.end();
 });
 
@@ -115,7 +114,7 @@ test("mschema.validate - mixed invalid and valid data - array of - string", func
   t.type(result.errors, Array)
   t.type(result.errors, Object);
   t.equal(result.errors.length, 1);
-  
+
   t.equal(result.errors[0].property, 'posts');
   t.equal(result.errors[0].constraint, 'type');
   t.equal(result.errors[0].value, 2);

--- a/test/array-typed-object-literal-test.js
+++ b/test/array-typed-object-literal-test.js
@@ -1,0 +1,144 @@
+var tap = require("tap"),
+    test = tap.test,
+    plan = tap.plan,
+    mschema;
+
+test("load mschema module", function (t) {
+  mschema = require('../');
+  t.ok(mschema, "mschema loaded");
+  t.end();
+});
+
+test("mschema.validate - valid data - array - object literal", function (t) {
+
+ var blog = {
+    "name": "string",
+    "posts": {
+      "type": "array",
+      "items": "string"
+    }
+  };
+
+  var data = {
+    "name": "My Blog",
+    "posts": ["first post", "another post", "third post"]
+  };
+
+  var result = mschema.validate(data, blog);
+  t.equal(result.valid, true);
+  t.ok(result, "data is valid");
+  t.end();
+
+});
+
+test("mschema.validate - invalid data - array - object literal", function (t) {
+
+  var blog = {
+     "name": "string",
+     "posts": {
+       "type": "array",
+       "items": "string",
+       "minItems": 1
+     },
+     "tags": {
+       "type": "array",
+       "items": "string",
+       "maxItems": 3
+     }
+   };
+
+   var data = {
+     "name": "My Blog",
+     "posts": [],
+     "tags": ["lol", "cringe", "gross", "orange"]
+   };
+
+   var result = mschema.validate(data, blog);
+   t.equal(result.valid, false);
+   t.type(result.errors, Array)
+   t.type(result.errors, Object);
+   t.equal(result.errors.length, 2);
+   t.equal(result.errors[0].property, 'posts');
+   t.equal(result.errors[0].constraint, 'minItems');
+   t.equal(result.errors[0].value, data.posts);
+   t.equal(result.errors[0].expected, 1);
+   t.equal(result.errors[0].actual, 0);
+   t.equal(result.errors[1].property, 'tags');
+   t.equal(result.errors[1].constraint, 'maxItems');
+   t.equal(result.errors[1].value, data.tags);
+   t.equal(result.errors[1].expected, 3);
+   t.equal(result.errors[1].actual, 4);
+   t.ok(result, "data is invalid");
+   t.end();
+
+ });
+
+test("mschema.validate - multiple array types in one array - valid data - object literal", function (t) {
+
+  var point = {
+    "name": {
+      "type": "string"
+    },
+    "coords": {
+      "type": "array",
+      "required": true,
+      "items": [{
+        "type": "number",
+        "min": -90,
+        "max": 90
+      }, {
+        "type": "number",
+        "min": -180,
+        "max": 180
+      }]
+    }
+  };
+
+  var data = {
+    "name": "missle base",
+    "coords": [42.544, -118.534]
+  };
+
+  var result = mschema.validate(data, point);
+
+  t.equal(result.valid, true);
+  t.ok(result, "data is valid");
+
+  t.end();
+});
+
+test("mschema.validate - multiple array types in one array - invalid data - object literal", function (t) {
+
+  var point = {
+    "name": {
+      "type": "string"
+    },
+    "coords": {
+      "type": "array",
+      "required": true,
+      "items": [{
+        "type": "number",
+        "min": -90,
+        "max": 90
+      }, {
+        "type": "number",
+        "min": -180,
+        "max": 180
+      }]
+    }
+  };
+
+  var data = {
+    "name": "missle base",
+    "coords": [500]
+  };
+
+  var result = mschema.validate(data, point);
+
+  t.equal(result.valid, false);
+  t.equal(result.errors.length, 2);
+  t.equal(result.errors[0].message, 'Value length does not match');
+  t.equal(result.errors[1].message, 'Value exceed max of property');
+  t.ok(result, "data is invalid");
+  t.end();
+});

--- a/test/object-non-object-value.js
+++ b/test/object-non-object-value.js
@@ -76,3 +76,34 @@ test("mschema.validate - invalid data - nested constraints", function (t) {
   t.end();
 
 });
+
+test("mschema.validate - invalid data - array", function (t) {
+
+  var user = {
+    "name": "string",
+    "age": "number",
+    "address": "object"
+  };
+
+  var data = {
+    "name": "Marak",
+    "age": 42,
+    "address": []
+  };
+
+  var result = mschema.validate(data, user);
+
+  t.equal(result.valid, false);
+  t.type(result.errors, Array)
+  t.type(result.errors, Object);
+  t.equal(result.errors.length, 1);
+  t.equal(result.errors[0].property, "address");
+  t.equal(result.errors[0].constraint, "type");
+  t.similar(result.errors[0].expected, "object");
+  t.equal(result.errors[0].actual, "array");
+  t.equal(result.errors[0].value, data.address);
+  t.ok(result, "data is invalid");
+
+  t.end();
+
+});


### PR DESCRIPTION
@Marak this is a bigger one. This PR extends the array-typed properties in mschema:

```js
{
  var point = {
    "name": {
      "type": "string"
    },
    "coords": {
      "type": "array",      // can use "array" type
      "required": true,     // can be required
      "items": [{           // `items` can be a string, object, or array of strings/objects
        "type": "number",   // if an array, the length has to match and the type(s) of each item
        "min": -90,
        "max": 90
      }, {
        "type": "number",   // each member can have a different type
        "min": -180,        // and different constraints
        "max": 180
      }]
    },
    "tags": {
      "type": "array",
      "minItems": 1,        // can have minimum # of items
      "maxItems": 10,       // and maximum # of items
      "items": {
        "type": "string"    // all items must be of the given type
      }
    }
  };
}
```

This PR also resolves an issue where an array is accepted as a value for object-typed properties.
